### PR TITLE
Update items for 1.19.10

### DIFF
--- a/items.json
+++ b/items.json
@@ -5586,7 +5586,7 @@
     "bedrock_data": 0
   },
   "minecraft:trader_llama_spawn_egg": {
-    "bedrock_identifier": "minecraft:llama_spawn_egg",
+    "bedrock_identifier": "minecraft:trader_llama_spawn_egg",
     "bedrock_data": 0
   },
   "minecraft:tropical_fish_spawn_egg": {


### PR DESCRIPTION
1.19.10 adds the trader llama spawn egg to Bedrock, so we don't need to convert to a llama spawn egg anymore. This should also fix issues where echo shards are appearing as trader llama spawn eggs to Bedrock players.

This will be a series of 3 PRs: one here, one in [mappings-generator](https://github.com/GeyserMC/mappings-generator/pull/44), and one in [Geyser](https://github.com/GeyserMC/Geyser/pull/3151). This is my first PR for Geyser, so any changes will be appreciated. You can get in touch with me on GitHub or Discord (masterjumblespeed#6935).