### PR TITLE
Fix block.crop.break sound

### DIFF
--- a/sounds.json
+++ b/sounds.json
@@ -1420,7 +1420,7 @@
     "identifier": "minecraft:creeper"
   },
   "block.crop.break": {
-    "playsound_mapping": "dig.grass",
+    "playsound_mapping": "block.bamboo_sapling.break",
     "bedrock_mapping": "BREAK_BLOCK"
   },
   "item.crop.plant": {


### PR DESCRIPTION
The `block.crop.break` sound plays `block.bamboo_sapling.break` on Java when used with `/playsound` instead of `dig.grass`. Note that this does not affect actually breaking crops, as that seems to be hardcoded into bedrock and still plays `dig.grass`.