### PR TITLE
fix: Wrong cow death sound

### DIFF
--- a/sounds.json
+++ b/sounds.json
@@ -1404,7 +1404,7 @@
     "bedrock_mapping": "AMBIENT"
   },
   "entity.cow.death": {
-    "playsound_mapping": "mob.fish.hurt",
+    "playsound_mapping": "mob.cow.hurt",
     "bedrock_mapping": "DEATH"
   },
   "entity.cow.hurt": {


### PR DESCRIPTION
This PR closes https://github.com/GeyserMC/Geyser/issues/5233, as the cow death sound was mapped to the fish hurt sound