### PR TITLE
Map the Lava Chicken music disc sound

### DIFF
--- a/items.json
+++ b/items.json
@@ -6669,7 +6669,7 @@
     "bedrock_data": 0
   },
   "minecraft:music_disc_lava_chicken": {
-    "bedrock_identifier": "minecraft:music_disc_chirp",
+    "bedrock_identifier": "minecraft:music_disc_lava_chicken",
     "bedrock_data": 0
   },
   "minecraft:music_disc_mall": {

--- a/sounds.json
+++ b/sounds.json
@@ -3661,7 +3661,10 @@
     "playsound_mapping": "record.far",
     "bedrock_mapping": "RECORD_FAR"
   },
-  "music_disc.lava_chicken": {},
+  "music_disc.lava_chicken": {
+    "playsound_mapping": "record.lava_chicken",
+    "bedrock_mapping": "RECORD_LAVA_CHICKEN"
+  },
   "music_disc.mall": {
     "playsound_mapping": "record.mall",
     "bedrock_mapping": "RECORD_MALL"


### PR DESCRIPTION
Support for protocol 819 got merged in Cloudburst, so we can map the Lava Chicken music disc sound now.